### PR TITLE
Allow Custom gunicorn Location Via Defaults File

### DIFF
--- a/tree/etc/init.d/gunicorn
+++ b/tree/etc/init.d/gunicorn
@@ -25,12 +25,12 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 . /lib/lsb/init-functions
 
 GUNICORN="/usr/bin/gunicorn"
-[ -x $GUNICORN ] || log_failure_msg "Can't find $GUNICORN"
 
 if [ -f /etc/default/$NAME ]; then
   . /etc/default/$NAME
 fi
 
+[ -x $GUNICORN ] || log_failure_msg "Can't find $GUNICORN"
 
 
 start_one()


### PR DESCRIPTION
Currently, the scripts use the GUNICORN variable to find the gunicorn executable.  Unfortunately, it checks to see if the variable works before it loads the /etc/default/gunicorn settings file, which prevents the user from overriding it in the case of an unusual location.  This patch moves the check further into the startup process, allowing a user to override the location.
